### PR TITLE
Add Angular login skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# auth
+# Angular Login Example
+
+Este repositorio contiene una estructura b\u00e1sica para una p\u00e1gina de login en Angular. Incluye componentes, servicios y modelos m\u00ednimos para autenticar un usuario.
+
+```
+src/
+  app/
+    app.module.ts
+    core/
+      services/
+        auth.service.ts
+    features/
+      auth/
+        auth.module.ts
+        login/
+          login.component.ts
+          login.component.html
+          login.component.css
+    models/
+      user.ts
+```
+
+El servicio `AuthService` expone un m\u00e9todo `login` que deber\u00eda conectarse con tu API real. El componente `LoginComponent` ofrece un formulario b\u00e1sico de usuario y contrase\u00f1a.
+
+Este c\u00f3digo est\u00e1 pensado como ejemplo de organizaci\u00f3n y no como implementaci\u00f3n final de seguridad.

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AuthModule } from './features/auth/auth.module';
+
+@NgModule({
+  declarations: [],
+  imports: [BrowserModule, AuthModule],
+  bootstrap: []
+})
+export class AppModule {}

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { User } from '../../models/user';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  login(username: string, password: string): Observable<User> {
+    // TODO: replace with real authentication logic
+    const user: User = { id: 1, username };
+    return of(user);
+  }
+}

--- a/src/app/features/auth/auth.module.ts
+++ b/src/app/features/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { LoginComponent } from './login/login.component';
+
+@NgModule({
+  declarations: [LoginComponent],
+  imports: [CommonModule, FormsModule],
+  exports: [LoginComponent]
+})
+export class AuthModule {}

--- a/src/app/features/auth/login/login.component.css
+++ b/src/app/features/auth/login/login.component.css
@@ -1,0 +1,14 @@
+form {
+  max-width: 300px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  margin-top: 1rem;
+}
+
+button {
+  margin-top: 1.5rem;
+}

--- a/src/app/features/auth/login/login.component.html
+++ b/src/app/features/auth/login/login.component.html
@@ -1,0 +1,11 @@
+<form (ngSubmit)="onSubmit()">
+  <div>
+    <label for="username">Username:</label>
+    <input id="username" name="username" [(ngModel)]="username" />
+  </div>
+  <div>
+    <label for="password">Password:</label>
+    <input id="password" name="password" type="password" [(ngModel)]="password" />
+  </div>
+  <button type="submit">Login</button>
+</form>

--- a/src/app/features/auth/login/login.component.ts
+++ b/src/app/features/auth/login/login.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css']
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+
+  constructor(private auth: AuthService) {}
+
+  onSubmit(): void {
+    this.auth.login(this.username, this.password).subscribe(user => {
+      console.log('Logged in user', user);
+    });
+  }
+}

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: number;
+  username: string;
+}


### PR DESCRIPTION
## Summary
- add small Angular module structure for login page
- include `AuthService` and `LoginComponent` skeletons
- document example structure in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847fefafd2083229b5765de78191c0e